### PR TITLE
Allow dashes to appear in class name

### DIFF
--- a/lib/dss_parser/parsers/states.rb
+++ b/lib/dss_parser/parsers/states.rb
@@ -9,7 +9,7 @@ class DssParser
           type, content = line.split(" ", 2)
 
           if type == "@state"
-            name, description = content.split("-", 2)
+            name, description = content.split(" - ", 2)
 
             states.push(Struct::State.new(name.strip, description.strip))
           end

--- a/lib/dss_parser/version.rb
+++ b/lib/dss_parser/version.rb
@@ -1,3 +1,3 @@
 class DssParser
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/fixtures/standard/forms.css.scss
+++ b/spec/fixtures/standard/forms.css.scss
@@ -38,6 +38,7 @@ input[type="text"] {
 // @state :disabled - Dims the button when disabled.
 // @state .primary - Indicates button is the primary action.
 // @state .smaller - A smaller button
+// @state .even-smaller - even smaller button
 //
 // @markup
 //   <button>markup<button>

--- a/spec/lib/dss_parser_spec.rb
+++ b/spec/lib/dss_parser_spec.rb
@@ -41,6 +41,18 @@ describe DssParser do
       expect(mixin.variables.first.description).to eq "A hex color at the top of the gradient"
 
     end
+
+    it 'allows dashes in class names' do
+      parser = DssParser.new(File.expand_path('./spec/fixtures/standard'))
+      comments = parser.get_dss
+
+      dss_button = comments[3]
+
+      dashed_state = dss_button.states.last
+
+      expect(dashed_state.name).to eq ".even-smaller"
+      expect(dashed_state.description).to eq "even smaller button"
+    end
   end
 
   it 'finds DSS comments within nested folders' do


### PR DESCRIPTION
Fix a bug that causes dashes in class name to cause the parser to break. 

a class name such as:
.class-name - a class name
would result in a name of ".class" and a description of "name - a class name" 

by spliting on " - " instead of just "-" it has been fixed but it does still rely on whitespace.  There may be a better way to do it.
